### PR TITLE
RA-196 failsafe snapshot support in EFSVSS

### DIFF
--- a/Samples/VShadowVolumeShadowCopy/cpp/break.cpp
+++ b/Samples/VShadowVolumeShadowCopy/cpp/break.cpp
@@ -297,7 +297,7 @@ void VssClient::MakeVolumesReadWrite(vector<wstring> snapshotVolumes)
                     uniqueVolumeName.c_str(), name.c_str(), iPack, iProvider);
 
                 // Check to see if this is one of our volumes. If not, continue
-                if (!FindStringInList(uniqueVolumeName, snapshotVolumeUniqueNames))
+                if (!FindStringInList(uniqueVolumeName, snapshotVolumeUniqueNames, false))
                     continue;
 
                 // Clear the read-only flag
@@ -322,7 +322,7 @@ void VssClient::MakeVolumesReadWrite(vector<wstring> snapshotVolumes)
         ft.WriteLine(L"WARNING: some volumes were not succesfully converted to read-write!");
 
         for (unsigned i = 0; i < snapshotVolumeUniqueNames.size(); i++)
-            if (!FindStringInList(snapshotVolumeUniqueNames[i], clearedVolumes))
+            if (!FindStringInList(snapshotVolumeUniqueNames[i], clearedVolumes, false))
                 ft.WriteLine(L"- Volume %s not found on the system. Clearing the read-only flag failed on it.",
                     snapshotVolumeUniqueNames[i].c_str());
     }

--- a/Samples/VShadowVolumeShadowCopy/cpp/create.cpp
+++ b/Samples/VShadowVolumeShadowCopy/cpp/create.cpp
@@ -194,7 +194,7 @@ void VssClient::SaveBackupComponentsDocument(wstring fileName)
 
 // Generate the SETVAR script
 // This is useful for management operations
-void VssClient::GenerateSetvarScript(wstring stringFileName)
+void VssClient::GenerateSetvarScript(wstring stringFileName, wstring stringSnapshotLevel)
 {
     FunctionTracer ft(DBG_INFO);
 
@@ -228,7 +228,12 @@ void VssClient::GenerateSetvarScript(wstring stringFileName)
         }
     }
 
-    ofile.close();
+	if (stringSnapshotLevel.size() > 0)
+	{
+		ofile << L"SET SNAPSHOT_LEVEL=" << stringSnapshotLevel.c_str() << L"\n";
+	}
+
+	ofile.close();
 }
 
 

--- a/Samples/VShadowVolumeShadowCopy/cpp/select.cpp
+++ b/Samples/VShadowVolumeShadowCopy/cpp/select.cpp
@@ -116,13 +116,19 @@ void VssClient::DiscoverDirectlyExcludedComponents(
         VssWriter & writer = writerList[iWriter];
 
         // Check if the writer is excluded
-        if (FindStringInList(writer.name, excludedWriterAndComponentList) || 
-            FindStringInList(writer.id, excludedWriterAndComponentList) ||
-            FindStringInList(writer.instanceId, excludedWriterAndComponentList))
+        if (FindStringInList(writer.name, excludedWriterAndComponentList, false) || 
+            FindStringInList(writer.id, excludedWriterAndComponentList, true) ||
+            FindStringInList(writer.instanceId, excludedWriterAndComponentList, true))
         {
-            writer.isExcluded = true;
+			ft.WriteLine(L" - Writer '%s' (id=%s, instance=%s) is explicitly excluded from backup ",
+				writer.name.c_str(), writer.id.c_str(), writer.instanceId.c_str());
+			writer.isExcluded = true;
             continue;
         }
+
+		// Do not exclude the Shadow Copy Optimization Writer just because it has no components
+		if (IsEqual(writer.id, L"{4dc3bdd4-ab48-4d07-adb0-3bee2926fd7f}"))
+			continue;
 
         // Check if the component is excluded
         for (unsigned iComponent = 0; iComponent < writer.components.size(); iComponent++)
@@ -138,9 +144,9 @@ void VssClient::DiscoverDirectlyExcludedComponents(
             wstring componentPathWithWriterIID = writer.instanceId + L":" + component.fullPath;
 
             // Check to see if this component is explicitly excluded
-            if (FindStringInList(componentPathWithWriterName, excludedWriterAndComponentList) || 
-                FindStringInList(componentPathWithWriterID, excludedWriterAndComponentList) ||
-                FindStringInList(componentPathWithWriterIID, excludedWriterAndComponentList))
+            if (FindStringInList(componentPathWithWriterName, excludedWriterAndComponentList, false) || 
+                FindStringInList(componentPathWithWriterID, excludedWriterAndComponentList, true) ||
+                FindStringInList(componentPathWithWriterIID, excludedWriterAndComponentList, true))
             {
                 ft.WriteLine(L"- Component '%s' from writer '%s' is explicitly excluded from backup ",
                     component.fullPath.c_str(), writer.name.c_str());
@@ -163,7 +169,7 @@ void VssClient::DiscoverDirectlyExcludedComponents(
         // If all components are missing or excluded, then exclude the writer too
         if (!nonExcludedComponents)
         {
-            ft.WriteLine(L"- Excluding writer '%s' since it has no selected components for restore.", writer.name.c_str());
+            ft.WriteLine(L"- Excluding writer '%s' since it has no selected components for backup.", writer.name.c_str());
             writer.isExcluded = true;
         }
     }
@@ -238,7 +244,7 @@ void VssClient::DiscoverNonShadowedExcludedComponents(
                     component.affectedVolumes[iVol] = wsUniquePath;
                 }
 
-                if (!FindStringInList(component.affectedVolumes[iVol], shadowSourceVolumes))
+                if (!FindStringInList(component.affectedVolumes[iVol], shadowSourceVolumes, false))
                 {
                     wstring wsLocalVolume;
 
@@ -315,6 +321,10 @@ void VssClient::DiscoverExcludedWriters()
         VssWriter & writer = m_writerList[iWriter];
         if (writer.isExcluded)
             continue;
+
+		// Do not exclude the Shadow Copy Optimization Writer just because it has no components
+		if (IsEqual(writer.id, L"{4dc3bdd4-ab48-4d07-adb0-3bee2926fd7f}"))
+			continue;
 
         // Discover if we have any:
         // - non-excluded selectable components 
@@ -695,7 +705,7 @@ bool VssClient::IsWriterSelected(GUID guidInstanceId)
 
 
 // Check the status for all selected writers
-void VssClient::CheckSelectedWriterStatus()
+void VssClient::CheckSelectedWriterStatus(bool bVerbose, bool bSilentlyIgnoreWriterFailures)
 {
     FunctionTracer ft(DBG_INFO);
 
@@ -710,63 +720,95 @@ void VssClient::CheckSelectedWriterStatus()
     unsigned cWriters = 0;
     CHECK_COM(m_pVssObject->GetWriterStatusCount(&cWriters));
 
+	// We must delay any failures until we have called GetWriterStatus on all writers.
+	HRESULT result = S_OK;
+
     // Enumerate each writer
     for(unsigned iWriter = 0; iWriter < cWriters; iWriter++)
     {
-        VSS_ID idInstance = GUID_NULL;
-        VSS_ID idWriter= GUID_NULL;
-        VSS_WRITER_STATE eWriterStatus = VSS_WS_UNKNOWN;
-        CComBSTR bstrWriterName;
-        HRESULT hrWriterFailure = S_OK;
+		try
+		{
+			VSS_ID idInstance = GUID_NULL;
+			VSS_ID idWriter = GUID_NULL;
+			VSS_WRITER_STATE eWriterStatus = VSS_WS_UNKNOWN;
+			CComBSTR bstrWriterName;
+			HRESULT hrWriterFailure = S_OK;
 
-        // Get writer status
-        CHECK_COM(m_pVssObject->GetWriterStatus(iWriter,
-                             &idInstance,
-                             &idWriter,
-                             &bstrWriterName,
-                             &eWriterStatus,
-                             &hrWriterFailure));
+			// Get writer status
+			CHECK_COM(m_pVssObject->GetWriterStatus(iWriter,
+				&idInstance,
+				&idWriter,
+				&bstrWriterName,
+				&eWriterStatus,
+				&hrWriterFailure));
 
-        // If the writer is not selected, just continue
-        if (!IsWriterSelected(idInstance))
-            continue;
+			// If the writer is not selected, just continue
+			if (!IsWriterSelected(idInstance))
+				continue;
 
-        // If the writer is in non-stable state, break
-        switch(eWriterStatus)
-        {
-            case VSS_WS_FAILED_AT_IDENTIFY:
-            case VSS_WS_FAILED_AT_PREPARE_BACKUP:
-            case VSS_WS_FAILED_AT_PREPARE_SNAPSHOT:
-            case VSS_WS_FAILED_AT_FREEZE:
-            case VSS_WS_FAILED_AT_THAW:
-            case VSS_WS_FAILED_AT_POST_SNAPSHOT:
-            case VSS_WS_FAILED_AT_BACKUP_COMPLETE:
-            case VSS_WS_FAILED_AT_PRE_RESTORE:
-            case VSS_WS_FAILED_AT_POST_RESTORE:
+			// If the writer is in non-stable state, break
+			switch (eWriterStatus)
+			{
+			case VSS_WS_FAILED_AT_IDENTIFY:
+			case VSS_WS_FAILED_AT_PREPARE_BACKUP:
+			case VSS_WS_FAILED_AT_PREPARE_SNAPSHOT:
+			case VSS_WS_FAILED_AT_FREEZE:
+			case VSS_WS_FAILED_AT_THAW:
+			case VSS_WS_FAILED_AT_POST_SNAPSHOT:
+			case VSS_WS_FAILED_AT_BACKUP_COMPLETE:
+			case VSS_WS_FAILED_AT_PRE_RESTORE:
+			case VSS_WS_FAILED_AT_POST_RESTORE:
 #ifdef VSS_SERVER
-            case VSS_WS_FAILED_AT_BACKUPSHUTDOWN:
+			case VSS_WS_FAILED_AT_BACKUPSHUTDOWN:
 #endif
-                break;
+				break;
 
-            default:
-                continue;
-        }
+			default:
+				if (bVerbose)
+				{
+					ft.WriteLine(L"  - Selected writer '%s' is OK (id=" WSTR_GUID_FMT L", instanceID=" WSTR_GUID_FMT L", status=%s)",
+						(PWCHAR)bstrWriterName,
+						GUID_PRINTF_ARG(idWriter),
+						GUID_PRINTF_ARG(idInstance),
+						GetStringFromWriterStatus(eWriterStatus).c_str()
+						);
+				}
+				continue;
+			}
 
-        // Print writer status
-        ft.WriteLine(L"\n"
-            L"ERROR: Selected writer '%s' is in failed state!\n"
-            L"   - Status: %d (%s)\n" 
-            L"   - Writer Failure code: 0x%08lx (%s)\n" 
-            L"   - Writer ID: " WSTR_GUID_FMT L"\n"
-            L"   - Instance ID: " WSTR_GUID_FMT L"\n",
-            (PWCHAR)bstrWriterName,
-            eWriterStatus, GetStringFromWriterStatus(eWriterStatus).c_str(), 
-            hrWriterFailure,FunctionTracer::HResult2String(hrWriterFailure).c_str(),
-            GUID_PRINTF_ARG(idWriter),
-            GUID_PRINTF_ARG(idInstance)
-            );
+			if (bSilentlyIgnoreWriterFailures)
+				continue;
 
-        // Stop here
-        throw(E_UNEXPECTED);
+			// Print writer status
+			ft.WriteLine(L"\n"
+				L"ERROR: Selected writer '%s' is in failed state!\n"
+				L"   - Status: %d (%s)\n"
+				L"   - Writer Failure code: 0x%08lx (%s)\n"
+				L"   - Writer ID: " WSTR_GUID_FMT L"\n"
+				L"   - Instance ID: " WSTR_GUID_FMT L"\n",
+				(PWCHAR)bstrWriterName,
+				eWriterStatus, GetStringFromWriterStatus(eWriterStatus).c_str(),
+				hrWriterFailure, FunctionTracer::HResult2String(hrWriterFailure).c_str(),
+				GUID_PRINTF_ARG(idWriter),
+				GUID_PRINTF_ARG(idInstance)
+			);
+
+			// Fail the operation after enumerating all writers
+			result = E_UNEXPECTED;
+		}
+		catch (HRESULT hr)
+		{
+			if (!bSilentlyIgnoreWriterFailures)
+			{
+				ft.WriteLine(L"\nERROR: GetWriterStatus failed in CheckSelectedWriterStatus (0x%08lx), will keep trying other writers...\n", hr);
+			}
+			if (S_OK == hr)
+				hr = E_UNEXPECTED;
+			result = hr;
+		}
     }
+
+	// Now we can propagate any error that occurred when checking all writers' status
+	if (S_OK != result && !bSilentlyIgnoreWriterFailures)
+		throw result;
 }

--- a/Samples/VShadowVolumeShadowCopy/cpp/util.h
+++ b/Samples/VShadowVolumeShadowCopy/cpp/util.h
@@ -218,12 +218,16 @@ inline bool IsEqual(wstring str1, wstring str2)
 
 // Returns TRUE if the string is already present in the string list  
 // (performs case insensitive comparison)
-inline bool FindStringInList(wstring str, vector<wstring> stringList)
+inline bool FindStringInList(wstring str, vector<wstring> stringList, bool isGUID)
 {
-    // Check to see if the volume is already added 
-    for (unsigned i = 0; i < stringList.size( ); i++)
-        if (IsEqual(str, stringList[i]))
-            return true;
+	// Check to see if the volume is already added 
+	for (unsigned i = 0; i < stringList.size(); i++)
+	{
+		if (IsEqual(str, stringList[i]))
+			return true;
+		if (isGUID && IsEqual(str, L"{" + stringList[i] + L"}"))
+			return true;
+	}
 
     return false;
 }

--- a/Samples/VShadowVolumeShadowCopy/cpp/vssclient.cpp
+++ b/Samples/VShadowVolumeShadowCopy/cpp/vssclient.cpp
@@ -24,6 +24,7 @@ VssClient::VssClient()
     m_latestSnapshotSetID = GUID_NULL;
     m_bDuringRestore = false;
     m_backupType = VSS_BT_FULL;
+	m_bIgnoreIndividualWriterGatherFailures = false;
 }
 
 
@@ -45,12 +46,17 @@ void VssClient::SetBackupType(VSS_BACKUP_TYPE backupType)
         m_backupType = backupType;
 }
 
+void VssClient::SetIgnoreIndividualWriterGatherFailures(bool v)
+{
+	m_bIgnoreIndividualWriterGatherFailures = v;
+}
+
 // Initialize the COM infrastructure and the internal pointers
 void VssClient::Initialize(DWORD dwContext, wstring xmlDoc, bool bDuringRestore)
 {
     FunctionTracer ft(DBG_INFO);
 
-    // Initialize COM 
+	// Initialize COM 
     CHECK_COM( CoInitialize(NULL) );
     m_bCoInitializeCalled = true;
 

--- a/Samples/VShadowVolumeShadowCopy/cpp/vssclient.h
+++ b/Samples/VShadowVolumeShadowCopy/cpp/vssclient.h
@@ -42,6 +42,9 @@ public:
     // Backup type setter
     void SetBackupType(VSS_BACKUP_TYPE backupType);
 
+	// Set whether or not to ignore failures to gather metadata of individual VSS writers
+	void SetIgnoreIndividualWriterGatherFailures(bool v);
+
     // Method to create a shadow copy set with the given volumes
     void CreateSnapshotSet(
         vector<wstring> volumeList, 
@@ -96,7 +99,10 @@ public:
     void DeleteAllSnapshots();
 
     // Delete the given shadow copy set 
-    void DeleteSnapshotSet(VSS_ID snapshotSetID);
+    void DeleteSnapshotSet(VSS_ID snapshotSetID, bool bIgnoreFailures);
+
+	// Delete the latest snapshot set that was taken (if any)
+	void DeleteLatestSnapshotSet(bool bIgnoreFailures);
 
     // Delete the given shadow copy
     void DeleteSnapshot(VSS_ID snapshotID);
@@ -244,7 +250,7 @@ public:
     bool IsWriterSelected(GUID guidInstanceId);
 
     // Check the status for all selected writers
-    void CheckSelectedWriterStatus();
+    void CheckSelectedWriterStatus(bool bVerbose, bool bSilentlyIgnoreWriterFailures);
 
 
 private:
@@ -294,5 +300,8 @@ private:
 
     // TRUE if we are during restore
     bool                            m_bDuringRestore;
+
+	// TRUE if we should ignore failures to gather individual writer metadata
+	bool                            m_bIgnoreIndividualWriterGatherFailures;
 };
 

--- a/Samples/VShadowVolumeShadowCopy/cpp/vssclient.h
+++ b/Samples/VShadowVolumeShadowCopy/cpp/vssclient.h
@@ -69,7 +69,7 @@ public:
     void ImportSnapshotSet();
 
     // Generate the SETVAR script for this shadow copy set
-    void GenerateSetvarScript(wstring stringFileName);
+    void GenerateSetvarScript(wstring stringFileName, wstring stringSnapshotLevel);
 
     // Marks all selected components as succeeded for backup
     void SetBackupSucceeded(bool succeeded);
@@ -145,7 +145,7 @@ public:
     //
 
     // Gather writer metadata
-    void GatherWriterMetadata();
+    void GatherWriterMetadata(bool bSkipDetails=false);
     void GatherWriterMetadataToScreen();
 
     // Gather writer status
@@ -161,7 +161,7 @@ public:
     void ListWriterMetadata(bool bListDetailedInfo);
 
     // List gathered writer status
-    void ListWriterStatus();
+    void ListWriterStatus(bool bMachineParseable);
 
     // Pre restore
     void PreRestore();

--- a/Samples/vshadow/src/break.cpp
+++ b/Samples/vshadow/src/break.cpp
@@ -198,7 +198,7 @@ void VssClient::MakeVolumesReadWrite(vector<wstring> snapshotVolumes)
                     uniqueVolumeName.c_str(), name.c_str(), iPack, iProvider);
 
                 // Check to see if this is one of our volumes. If not, continue
-                if (!FindStringInList(uniqueVolumeName, snapshotVolumeUniqueNames))
+                if (!FindStringInList(uniqueVolumeName, snapshotVolumeUniqueNames, false))
                     continue;
 
                 // Clear the read-only flag
@@ -223,7 +223,7 @@ void VssClient::MakeVolumesReadWrite(vector<wstring> snapshotVolumes)
         ft.WriteLine(L"WARNING: some volumes were not succesfully converted to read-write!");
 
         for (unsigned i = 0; i < snapshotVolumeUniqueNames.size(); i++)
-            if (!FindStringInList(snapshotVolumeUniqueNames[i], clearedVolumes))
+            if (!FindStringInList(snapshotVolumeUniqueNames[i], clearedVolumes, false))
                 ft.WriteLine(L"- Volume %s not found on the system. Clearing the read-only flag failed on it.",
                     snapshotVolumeUniqueNames[i].c_str());
     }

--- a/Samples/vshadow/src/create.cpp
+++ b/Samples/vshadow/src/create.cpp
@@ -77,7 +77,7 @@ void VssClient::PrepareForBackup()
     WaitAndCheckForAsyncOperation(pAsync);
 
     // Check selected writer status
-    CheckSelectedWriterStatus();
+    CheckSelectedWriterStatus(false, false);
 }
 
 
@@ -122,8 +122,33 @@ void VssClient::DoSnapshotSet()
     // Waits for the async operation to finish and checks the result
     WaitAndCheckForAsyncOperation(pAsync);
 
-    // Check selected writer status
-    CheckSelectedWriterStatus();
+	try
+	{
+		// Check selected writer status
+		CheckSelectedWriterStatus(true, false);
+	}
+	catch (...)
+	{
+		try
+		{
+			// DoSnapshotSet succeeded, but checking writer status failed.
+			// We need to tell VSS that we consider the backup as failed.
+			// However, it's important to ignore failures as we do so.
+			ft.WriteLine(L"Telling VSS writers that we consider this VSS backup as failed...");
+			SetBackupSucceeded(false);
+			CComPtr<IVssAsync>  pAsyncBC;
+			if (S_OK == m_pVssObject->BackupComplete(&pAsyncBC))
+			{
+				WaitAndCheckForAsyncOperation(pAsyncBC);
+			}
+			// After calling BackupComplete, per VSS protocol we have to gather writer status again!
+			CheckSelectedWriterStatus(false, true);
+		}
+		catch (...) {}
+
+		// Make sure that we propagate the error checking writer status
+		throw;
+	}
 
     ft.WriteLine(L"Shadow copy set succesfully created.");
 }
@@ -135,13 +160,13 @@ void VssClient::BackupComplete(bool succeeded)
     FunctionTracer ft(DBG_INFO);
 
     if (succeeded)
-        ft.WriteLine(L"- Mark all writers as succesfully backed up... ");
+        ft.WriteLine(L"- Mark all VSS writers as successfully backed up... ");
     else
-        ft.WriteLine(L"- Backup failed. Mark all writers as not succesfully backed up... ");
+        ft.WriteLine(L"- VSS backup sequence failed. Mark all writers as not successfully backed up... ");
 
     SetBackupSucceeded(succeeded);
 
-    ft.WriteLine(L"Completing the backup (BackupComplete) ... ");
+    ft.WriteLine(L"Completing the VSS backup sequence (BackupComplete) ... ");
 
     CComPtr<IVssAsync>  pAsync;
     CHECK_COM(m_pVssObject->BackupComplete(&pAsync));
@@ -150,7 +175,7 @@ void VssClient::BackupComplete(bool succeeded)
     WaitAndCheckForAsyncOperation(pAsync);
 
     // Check selected writer status
-    CheckSelectedWriterStatus();
+    CheckSelectedWriterStatus(false, false);
 
 }
 
@@ -252,14 +277,26 @@ void VssClient::SetBackupSucceeded(bool succeeded)
             if (!component.isExplicitlyIncluded || !component.notifyOnBackupComplete)
                 continue;
 
-            // Call SetBackupSucceeded for this component
-            CHECK_COM(m_pVssObject->SetBackupSucceeded(
-                WString2Guid(writer.instanceId),
-                WString2Guid(writer.id),
-                component.type,
-                component.logicalPath.c_str(),
-                component.name.c_str(),
-                succeeded));
+			try
+			{
+				// Call SetBackupSucceeded for this component
+				CHECK_COM(m_pVssObject->SetBackupSucceeded(
+					WString2Guid(writer.instanceId),
+					WString2Guid(writer.id),
+					component.type,
+					component.logicalPath.c_str(),
+					component.name.c_str(),
+					succeeded));
+			}
+			catch (HRESULT hr)
+			{
+				if (succeeded) {
+					// this error must propagate
+					throw hr;
+				}
+				// this is non-fatal for failed backups, keep trying to notify for all components
+				ft.WriteLine(L"WARNING: failed to notify backup failure for writer %s component %s %s\n", writer.id.c_str(), component.logicalPath.c_str(), component.name.c_str());
+			}
         }
     }
 }

--- a/Samples/vshadow/src/create.cpp
+++ b/Samples/vshadow/src/create.cpp
@@ -173,7 +173,7 @@ void VssClient::SaveBackupComponentsDocument(wstring fileName)
 
 // Generate the SETVAR script
 // This is useful for management operations
-void VssClient::GenerateSetvarScript(wstring stringFileName)
+void VssClient::GenerateSetvarScript(wstring stringFileName, wstring stringSnapshotLevel)
 {
     FunctionTracer ft(DBG_INFO);
 
@@ -206,6 +206,11 @@ void VssClient::GenerateSetvarScript(wstring stringFileName)
             ofile << L"SET SHADOW_DEVICE_" << i+1 << L"=" << Snap.m_pwszSnapshotDeviceObject << L"\n";
         }
     }
+
+	if (stringSnapshotLevel.size() > 0)
+	{
+		ofile << L"SET SNAPSHOT_LEVEL=" << stringSnapshotLevel.c_str() << L"\n";
+	}
 
     ofile.close();
 }

--- a/Samples/vshadow/src/delete.cpp
+++ b/Samples/vshadow/src/delete.cpp
@@ -82,7 +82,7 @@ void VssClient::DeleteAllSnapshots()
 
 
 // Delete the given shadow copy set 
-void VssClient::DeleteSnapshotSet(VSS_ID snapshotSetID)
+void VssClient::DeleteSnapshotSet(VSS_ID snapshotSetID, bool bIgnoreFailures)
 {
     FunctionTracer ft(DBG_INFO);
 
@@ -101,10 +101,24 @@ void VssClient::DeleteSnapshotSet(VSS_ID snapshotSetID)
 
     if (FAILED(hr))
     {
-        ft.WriteLine(L"Error while deleting shadow copies...");
+        ft.WriteLine(L"Error while deleting shadow copies... (hr=0x%08lx)", hr);
         ft.WriteLine(L"- Last shadow copy that could not be deleted: " WSTR_GUID_FMT, GUID_PRINTF_ARG(idNonDeletedSnapshotID));
-        CHECK_COM_ERROR(hr, L"m_pVssObject->DeleteSnapshots(snapshotSetID, VSS_OBJECT_SNAPSHOT_SET,FALSE,&lSnapshots,&idNonDeleted)");
+		if (!bIgnoreFailures)
+		{
+			CHECK_COM_ERROR(hr, L"m_pVssObject->DeleteSnapshots(snapshotSetID, VSS_OBJECT_SNAPSHOT_SET,FALSE,&lSnapshots,&idNonDeleted)");
+		}
     }
+}
+
+// Delete the latest snapshot set that was taken (if any)
+void VssClient::DeleteLatestSnapshotSet(bool bIgnoreFailures)
+{
+	FunctionTracer ft(DBG_INFO);
+
+	if (GUID_NULL == m_latestSnapshotSetID)
+		return;
+
+	DeleteSnapshotSet(m_latestSnapshotSetID, bIgnoreFailures);
 }
 
 void VssClient::DeleteOldestSnapshot(const wstring& stringVolumeName)

--- a/Samples/vshadow/src/shadow.cpp
+++ b/Samples/vshadow/src/shadow.cpp
@@ -37,7 +37,7 @@ extern "C" int __cdecl wmain(__in int argc, __in_ecount(argc) WCHAR ** argv)
             L"\n"
             L"EFSVSS.EXE 2.2 - Volume Shadow Copy client.\n"
 			L"Portions copyright(C) 2005 Microsoft Corporation. All rights reserved.\n"
-			L"Portions copyright(C) 2017 eFolder Inc. All rights reserved.\n"
+			L"Portions copyright(C) 2017-2018 eFolder Inc. All rights reserved.\n"
 			L"\n");
         
         // Build the argument vector 
@@ -218,6 +218,14 @@ int CommandLineParser::MainRoutine(vector<wstring> arguments)
 			continue;
 		}
 
+		// Check for ignore gather writer metadata failure
+		if (MatchArgument(arguments[argIndex], L"iwgf"))
+		{
+			ft.WriteLine(L"(Option: Ignore Individual Writer Gather Failures)");
+			m_vssClient.SetIgnoreIndividualWriterGatherFailures(true);
+			continue;
+		}
+
         // Check for the command execution option
         if (MatchArgument(arguments[argIndex], L"exec", execCommand))
         {
@@ -354,7 +362,7 @@ int CommandLineParser::MainRoutine(vector<wstring> arguments)
             m_vssClient.Initialize(VSS_CTX_ALL);
 
             // Gather writer metadata
-            m_vssClient.DeleteSnapshotSet(deletingSnapshotSetID);
+            m_vssClient.DeleteSnapshotSet(deletingSnapshotSetID, false);
 
             return 0;
         }
@@ -624,7 +632,7 @@ int CommandLineParser::MainRoutine(vector<wstring> arguments)
             try
             {
                 // Check selected writer status
-                m_vssClient.CheckSelectedWriterStatus();
+                m_vssClient.CheckSelectedWriterStatus(false, false);
 
                 // Executing the custom command if needed
                 if (execCommand.length() > 0)
@@ -649,7 +657,7 @@ int CommandLineParser::MainRoutine(vector<wstring> arguments)
             m_vssClient.PostRestore();
 
             // Check selected writer status
-            m_vssClient.CheckSelectedWriterStatus();
+            m_vssClient.CheckSelectedWriterStatus(false, false);
 
             ft.WriteLine(L"\nRestore done.");
             
@@ -721,43 +729,57 @@ int CommandLineParser::MainRoutine(vector<wstring> arguments)
             dwContext = UpdateFinalContext(dwContext);
             m_vssClient.Initialize(dwContext);
 
-            // Create the shadow copy set
-            m_vssClient.CreateSnapshotSet(
-                volumeList, 
-                xmlBackupComponentsDoc, 
-                excludedWriterList,
-                includedWriterList
-                );
+			try
+			{
+				// Create the shadow copy set
+				m_vssClient.CreateSnapshotSet(
+					volumeList, 
+					xmlBackupComponentsDoc, 
+					excludedWriterList,
+					includedWriterList
+					);
 
-            try
-            {
-                // Generate management scripts if needed
-                if (stringFileName.length() > 0)
-                    m_vssClient.GenerateSetvarScript(stringFileName, stringSnapshotLevel);
+				try
+				{
+					// Generate management scripts if needed
+					if (stringFileName.length() > 0)
+						m_vssClient.GenerateSetvarScript(stringFileName, stringSnapshotLevel);
 
-                // Executing the custom command if needed
-                if (execCommand.length() > 0)
-                    ExecCommand(execCommand);
+					// Executing the custom command if needed
+					if (execCommand.length() > 0)
+						ExecCommand(execCommand);
 
-            }
-            catch(HRESULT)
-            {
-                // Mark backup failure and exit
-                if ((dwContext & VSS_VOLSNAP_ATTR_NO_WRITERS) == 0)
-                    m_vssClient.BackupComplete(false);
+				}
+				catch(HRESULT)
+				{
+					// Mark backup failure and exit
+					if ((dwContext & VSS_VOLSNAP_ATTR_NO_WRITERS) == 0)
+						m_vssClient.BackupComplete(false);
 
-                throw;
-            }
+					throw;
+				}
 
-            // Complete the backup
-            // Note that this will notify writers that the backup is succesful! 
-            // (which means eventually log truncation)
-            if ((dwContext & VSS_VOLSNAP_ATTR_NO_WRITERS) == 0)
-                m_vssClient.BackupComplete(true);
+				// Complete the backup
+				// Note that this will notify writers that the backup is succesful! 
+				// (which means eventually log truncation)
+				if ((dwContext & VSS_VOLSNAP_ATTR_NO_WRITERS) == 0)
+					m_vssClient.BackupComplete(true);
 
-            ft.WriteLine(L"\nSnapshot creation done.");
+				ft.WriteLine(L"\nSnapshot creation done.");
             
-            return 0;
+				return 0;
+			}
+			catch (...)
+			{
+				try
+				{
+					ft.WriteLine(L"\nFailed to fully create VSS snapshot, so ensuring that any half-created VSS snapshot gets deleted...");
+					m_vssClient.DeleteLatestSnapshotSet(true);
+				}
+				catch (...) {}
+				// It's important to rethrow the exception so normal error handling continues as before
+				throw;
+			}
         }
 
         // No match. Print an error and the usage
@@ -860,8 +882,9 @@ void CommandLineParser::PrintUsage()
         L"  -wi={Writer Name}  - Verify that a writer/component is included\n"
         L"  -wx={Writer Name}  - Exclude a writer/component from set creation or restore\n"
         L"  -script={file.cmd} - SETVAR script creation\n"
-		L"  -snaplevel={...}   - User-specified snapshot level that will be set in the SETVAR script."
-        L"  -exec={command}    - Custom command executed after shadow creation, import or between break and make-it-write\n"
+		L"  -snaplevel={...}   - User-specified snapshot level that will be set in the SETVAR script.\n"
+		L"  -iwgf              - Ignore failure to gather metadata of one VSS writer.\n"
+		L"  -exec={command}    - Custom command executed after shadow creation, import or between break and make-it-write\n"
         L"  -wait              - Wait before program termination or between shadow set break and make-it-write\n"
         L"  -tracing           - Runs EFSVSS.EXE with enhanced diagnostics\n"
         L"\n"
@@ -924,7 +947,8 @@ void CommandLineParser::PrintUsage()
         L"  -wx={Writer Name}  - Exclude a writer/component from set creation or restore\n"
         L"  -bc={file.xml}     - Generates the backup components document during shadow creation.\n"
         L"  -script={file.cmd} - SETVAR script creation\n"
-		L"  -snaplevel={...}   - User-specified snapshot level that will be set in the SETVAR script."
+		L"  -snaplevel={...}   - User-specified snapshot level that will be set in the SETVAR script.\n"
+		L"  -iwgf              - Ignore failure to gather metadata of one VSS writer.\n"
 		L"  -exec={command}    - Custom command executed after shadow creation\n"
         L"  -wait              - Wait before program termination \n"
         L"  -tracing           - Runs EFSVSS.EXE with enhanced diagnostics\n"

--- a/Samples/vshadow/src/util.h
+++ b/Samples/vshadow/src/util.h
@@ -209,14 +209,18 @@ inline bool IsEqual(wstring str1, wstring str2)
 
 // Returns TRUE if the string is already present in the string list  
 // (performs case insensitive comparison)
-inline bool FindStringInList(wstring str, vector<wstring> stringList)
+inline bool FindStringInList(wstring str, vector<wstring> stringList, bool isGUID)
 {
-    // Check to see if the volume is already added 
-    for (unsigned i = 0; i < stringList.size( ); i++)
-        if (IsEqual(str, stringList[i]))
-            return true;
+	// Check to see if the volume is already added 
+	for (unsigned i = 0; i < stringList.size(); i++)
+	{
+		if (IsEqual(str, stringList[i]))
+			return true;
+		if (isGUID && IsEqual(str, L"{" + stringList[i] + L"}"))
+			return true;
+	}
 
-    return false;
+	return false;
 }
 
 

--- a/Samples/vshadow/src/vssclient.cpp
+++ b/Samples/vshadow/src/vssclient.cpp
@@ -24,6 +24,7 @@ VssClient::VssClient()
     m_latestSnapshotSetID = GUID_NULL;
     m_bDuringRestore = false;
     m_backupType = VSS_BT_FULL;
+	m_bIgnoreIndividualWriterGatherFailures = false;
 }
 
 
@@ -45,12 +46,17 @@ void VssClient::SetBackupType(VSS_BACKUP_TYPE backupType)
         m_backupType = backupType;
 }
 
+void VssClient::SetIgnoreIndividualWriterGatherFailures(bool v)
+{
+	m_bIgnoreIndividualWriterGatherFailures = v;
+}
+
 // Initialize the COM infrastructure and the internal pointers
 void VssClient::Initialize(DWORD dwContext, wstring xmlDoc, bool bDuringRestore)
 {
     FunctionTracer ft(DBG_INFO);
 
-    // Initialize COM 
+	// Initialize COM 
     CHECK_COM( CoInitialize(NULL) );
     m_bCoInitializeCalled = true;
 

--- a/Samples/vshadow/src/vssclient.h
+++ b/Samples/vshadow/src/vssclient.h
@@ -42,6 +42,9 @@ public:
     // Backup type setter
     void SetBackupType(VSS_BACKUP_TYPE backupType);
 
+	// Set whether or not to ignore failures to gather metadata of individual VSS writers
+	void SetIgnoreIndividualWriterGatherFailures(bool v);
+
     // Method to create a shadow copy set with the given volumes
     void CreateSnapshotSet(
         vector<wstring> volumeList, 
@@ -96,7 +99,10 @@ public:
     void DeleteAllSnapshots();
 
     // Delete the given shadow copy set 
-    void DeleteSnapshotSet(VSS_ID snapshotSetID);
+    void DeleteSnapshotSet(VSS_ID snapshotSetID, bool bIgnoreFailures);
+
+	// Delete the latest snapshot set that was taken (if any)
+	void DeleteLatestSnapshotSet(bool bIgnoreFailures);
 
     // Delete the given shadow copy
     void DeleteSnapshot(VSS_ID snapshotID);
@@ -236,7 +242,7 @@ public:
     bool IsWriterSelected(GUID guidInstanceId);
 
     // Check the status for all selected writers
-    void CheckSelectedWriterStatus();
+    void CheckSelectedWriterStatus(bool bVerbose, bool bSilentlyIgnoreWriterFailures);
 
 
 private:
@@ -283,5 +289,8 @@ private:
 
     // TRUE if we are during restore
     bool                            m_bDuringRestore;
+
+	// TRUE if we should ignore failures to gather individual writer metadata
+	bool                            m_bIgnoreIndividualWriterGatherFailures;
 };
 

--- a/Samples/vshadow/src/vssclient.h
+++ b/Samples/vshadow/src/vssclient.h
@@ -69,7 +69,7 @@ public:
     void ImportSnapshotSet();
 
     // Generate the SETVAR script for this shadow copy set
-    void GenerateSetvarScript(wstring stringFileName);
+    void GenerateSetvarScript(wstring stringFileName, wstring stringSnapshotLevel);
 
     // Marks all selected components as succeeded for backup
     void SetBackupSucceeded(bool succeeded);
@@ -138,7 +138,7 @@ public:
     //
 
     // Gather writer metadata
-    void GatherWriterMetadata();
+    void GatherWriterMetadata(bool bSkipDetails = false);
 
     // Gather writer status
     void GatherWriterStatus();
@@ -153,7 +153,7 @@ public:
     void ListWriterMetadata(bool bListDetailedInfo);
 
     // List gathered writer status
-    void ListWriterStatus();
+    void ListWriterStatus(bool bMachineParseable);
 
     // Pre restore
     void PreRestore();

--- a/Samples/vshadow/src/writer.cpp
+++ b/Samples/vshadow/src/writer.cpp
@@ -22,7 +22,7 @@
 
 
 // Gather writers metadata
-void VssClient::GatherWriterMetadata()
+void VssClient::GatherWriterMetadata(bool bSkipDetails)
 {
     FunctionTracer ft(DBG_INFO);
 
@@ -36,10 +36,12 @@ void VssClient::GatherWriterMetadata()
     // Waits for the async operation to finish and checks the result
     WaitAndCheckForAsyncOperation(pAsync);
 
-    ft.WriteLine(L"Initialize writer metadata ...");   
+	if (!bSkipDetails) {
+		ft.WriteLine(L"Initialize writer metadata ...");
 
-    // Initialize the internal metadata data structures
-    InitializeWriterMetadata();
+		// Initialize the internal metadata data structures
+		InitializeWriterMetadata();
+	}
 }
 
 
@@ -49,7 +51,7 @@ void VssClient::GatherWriterStatus()
     FunctionTracer ft(DBG_INFO);
 
     // Gathers writer status
-    // WARNING: GatherWriterMetadata must be called before
+	// (WARNING: GatherWriterMetadata must be called before, but you can set bSkipDetails=true)
     CComPtr<IVssAsync>  pAsync;
     CHECK_COM(m_pVssObject->GatherWriterStatus(&pAsync));
 
@@ -161,7 +163,7 @@ void VssClient::ListWriterMetadata(bool bListDetailedInfo)
 
 
 // Lists the status for all writers
-void VssClient::ListWriterStatus()
+void VssClient::ListWriterStatus(bool bMachineParseable)
 {
     FunctionTracer ft(DBG_INFO);
 
@@ -172,6 +174,11 @@ void VssClient::ListWriterStatus()
     unsigned cWriters = 0;
     CHECK_COM(m_pVssObject->GetWriterStatusCount(&cWriters));
     ft.WriteLine(L"- Number of writers that responded: %u", cWriters);  
+
+	if (bMachineParseable)
+	{
+		ft.WriteLine(L"HEADER|statuscode|statusname|failcode|faildesc|writer_id|instance_id|name");
+	}
 
     // Enumerate each writer
     for(unsigned iWriter = 0; iWriter < cWriters; iWriter++)
@@ -190,19 +197,33 @@ void VssClient::ListWriterStatus()
                              &eWriterStatus,
                              &hrWriterFailure));
 
-        // Print writer status
-        ft.WriteLine(L"\n"
-            L"* WRITER \"%s\"\n"
-            L"   - Status: %d (%s)\n" 
-            L"   - Writer Failure code: 0x%08lx (%s)\n" 
-            L"   - Writer ID: " WSTR_GUID_FMT L"\n"
-            L"   - Instance ID: " WSTR_GUID_FMT L"\n",
-            (PWCHAR)bstrWriterName,
-            eWriterStatus, GetStringFromWriterStatus(eWriterStatus).c_str(), 
-            hrWriterFailure, FunctionTracer::HResult2String(hrWriterFailure).c_str(),
-            GUID_PRINTF_ARG(idWriter),
-            GUID_PRINTF_ARG(idInstance)
-            );
+		// Print writer status
+		if (!bMachineParseable)
+		{
+			ft.WriteLine(L"\n"
+				L"* WRITER \"%s\"\n"
+				L"   - Status: %d (%s)\n" 
+				L"   - Writer Failure code: 0x%08lx (%s)\n" 
+				L"   - Writer ID: " WSTR_GUID_FMT L"\n"
+				L"   - Instance ID: " WSTR_GUID_FMT L"\n",
+				(PWCHAR)bstrWriterName,
+				eWriterStatus, GetStringFromWriterStatus(eWriterStatus).c_str(), 
+				hrWriterFailure, FunctionTracer::HResult2String(hrWriterFailure).c_str(),
+				GUID_PRINTF_ARG(idWriter),
+				GUID_PRINTF_ARG(idInstance)
+				);
+		}
+		else
+		{
+			ft.WriteLine(
+				L"WRITER|%d|%s|0x%08lx|%s|" WSTR_GUID_FMT L"|" WSTR_GUID_FMT L"|%s",
+				eWriterStatus, GetStringFromWriterStatus(eWriterStatus).c_str(),
+				hrWriterFailure, FunctionTracer::HResult2String(hrWriterFailure).c_str(),
+				GUID_PRINTF_ARG(idWriter),
+				GUID_PRINTF_ARG(idInstance),
+				(PWCHAR)bstrWriterName
+			);
+		}
     }
 }
     


### PR DESCRIPTION
This is required modifications to efsvss to support RA-196 functionality in the agent. Most of the logic will be in a companion PR within the agent.

This adds the following to efsvss:

`-wsml` command lists writer status in a format that is easier to parse. Also, this command no longer queries detailed writer metadata and only queries for status, so it is much faster and less resource intensive on the system.

`-snaplevel=x` option allows you to set a custom "snapshot level" value that will be remembered in the SETVAR script file that gets created. The snapshot level is user-defined and does not change any behavior of taking the VSS snapshot.