### PR TITLE
Feature RA-1467: change version to 2.27.0.0

### DIFF
--- a/Samples/VShadowVolumeShadowCopy/cpp/vshadow.rc
+++ b/Samples/VShadowVolumeShadowCopy/cpp/vshadow.rc
@@ -11,7 +11,7 @@
 
 VS_VERSION_INFO VERSIONINFO
 FILEVERSION 6,4,0,0
-PRODUCTVERSION 2,25,0,0
+PRODUCTVERSION 2,26,0,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -33,7 +33,7 @@ BEGIN
             VALUE "LegalCopyright", "Copyright (C) 2016-2019 eFolder, Inc. All Rights Reserved."
             VALUE "OriginalFilename", "efsvss-2008.exe"
             VALUE "ProductName", "Replibit Backup Agent"
-            VALUE "ProductVersion", "2.25"
+            VALUE "ProductVersion", "2.26"
         END
     END
     BLOCK "VarFileInfo"

--- a/Samples/VShadowVolumeShadowCopy/cpp/vshadow.rc
+++ b/Samples/VShadowVolumeShadowCopy/cpp/vshadow.rc
@@ -11,7 +11,7 @@
 
 VS_VERSION_INFO VERSIONINFO
 FILEVERSION 6,4,0,0
-PRODUCTVERSION 2,26,0,0
+PRODUCTVERSION 2,27,0,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -33,7 +33,7 @@ BEGIN
             VALUE "LegalCopyright", "Copyright (C) 2016-2019 eFolder, Inc. All Rights Reserved."
             VALUE "OriginalFilename", "efsvss-2008.exe"
             VALUE "ProductName", "Replibit Backup Agent"
-            VALUE "ProductVersion", "2.26"
+            VALUE "ProductVersion", "2.27"
         END
     END
     BLOCK "VarFileInfo"

--- a/Samples/vshadow/src/vshadow.rc
+++ b/Samples/vshadow/src/vshadow.rc
@@ -50,8 +50,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
-FILEVERSION 2,25,0,0
-PRODUCTVERSION 2,25,0,0
+FILEVERSION 2,26,0,0
+PRODUCTVERSION 2,26,0,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -68,12 +68,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "eFolder, Inc."
             VALUE "FileDescription", "Replibit Shadow Copy Requestor"
-            VALUE "FileVersion", "2.25.0.0"
+            VALUE "FileVersion", "2.26.0.0"
             VALUE "InternalName", "efsvss-2003.exe"
             VALUE "LegalCopyright", "Copyright (C) 2016-2019 eFolder, Inc. All Rights Reserved."
             VALUE "OriginalFilename", "efsvss-2003.exe"
             VALUE "ProductName", "Replibit Backup Agent"
-            VALUE "ProductVersion", "2.25"
+            VALUE "ProductVersion", "2.26"
         END
     END
     BLOCK "VarFileInfo"

--- a/Samples/vshadow/src/vshadow.rc
+++ b/Samples/vshadow/src/vshadow.rc
@@ -50,8 +50,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
-FILEVERSION 2,26,0,0
-PRODUCTVERSION 2,26,0,0
+FILEVERSION 2,27,0,0
+PRODUCTVERSION 2,27,0,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -68,12 +68,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "eFolder, Inc."
             VALUE "FileDescription", "Replibit Shadow Copy Requestor"
-            VALUE "FileVersion", "2.26.0.0"
+            VALUE "FileVersion", "2.27.0.0"
             VALUE "InternalName", "efsvss-2003.exe"
             VALUE "LegalCopyright", "Copyright (C) 2016-2019 eFolder, Inc. All Rights Reserved."
             VALUE "OriginalFilename", "efsvss-2003.exe"
             VALUE "ProductName", "Replibit Backup Agent"
-            VALUE "ProductVersion", "2.26"
+            VALUE "ProductVersion", "2.27"
         END
     END
     BLOCK "VarFileInfo"


### PR DESCRIPTION
We currently do not track release branch for this repository. Because of this, we should not move to version 2.26 until 2.25 is complete. I know, we may need to release a hotfix for 2.25 once we have merged this, but we can revert or do something like that if needed. Right now we _expect_ more pushes to 2.25.
Moreover, this repository rarely changes.
NOTE: I could not find Anatoly Z here