### PR TITLE
Feature RA-1467: change version to 2.28.0.0

### DIFF
--- a/Samples/VShadowVolumeShadowCopy/cpp/vshadow.rc
+++ b/Samples/VShadowVolumeShadowCopy/cpp/vshadow.rc
@@ -11,7 +11,7 @@
 
 VS_VERSION_INFO VERSIONINFO
 FILEVERSION 6,4,0,0
-PRODUCTVERSION 2,27,0,0
+PRODUCTVERSION 2,28,0,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -33,7 +33,7 @@ BEGIN
             VALUE "LegalCopyright", "Copyright (C) 2016-2019 eFolder, Inc. All Rights Reserved."
             VALUE "OriginalFilename", "efsvss-2008.exe"
             VALUE "ProductName", "Replibit Backup Agent"
-            VALUE "ProductVersion", "2.27"
+            VALUE "ProductVersion", "2.28"
         END
     END
     BLOCK "VarFileInfo"

--- a/Samples/vshadow/src/vshadow.rc
+++ b/Samples/vshadow/src/vshadow.rc
@@ -50,8 +50,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
-FILEVERSION 2,27,0,0
-PRODUCTVERSION 2,27,0,0
+FILEVERSION 2,28,0,0
+PRODUCTVERSION 2,28,0,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -68,12 +68,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "eFolder, Inc."
             VALUE "FileDescription", "Replibit Shadow Copy Requestor"
-            VALUE "FileVersion", "2.27.0.0"
+            VALUE "FileVersion", "2.28.0.0"
             VALUE "InternalName", "efsvss-2003.exe"
             VALUE "LegalCopyright", "Copyright (C) 2016-2019 eFolder, Inc. All Rights Reserved."
             VALUE "OriginalFilename", "efsvss-2003.exe"
             VALUE "ProductName", "Replibit Backup Agent"
-            VALUE "ProductVersion", "2.27"
+            VALUE "ProductVersion", "2.28"
         END
     END
     BLOCK "VarFileInfo"


### PR DESCRIPTION
We currently do not track release branch for this repository. Because of this, we should not move to version 2.28 until 2.27 is complete.