### PR TITLE
[RA-3034] Better efsvss messaging

### DIFF
--- a/Samples/vshadow/src/shadow.cpp
+++ b/Samples/vshadow/src/shadow.cpp
@@ -69,6 +69,8 @@ extern "C" int __cdecl wmain(__in int argc, __in_ecount(argc) WCHAR ** argv)
     }
 }
 
+// Try to rethrow caught exception and return it's description
+// Should be used for huge try blocks where we expect a different exceptions thrown
 std::string getCurrentExceptionDescription(const std::exception_ptr& ex = std::current_exception())
 {
 	if (ex == nullptr)

--- a/Samples/vshadow/src/shadow.cpp
+++ b/Samples/vshadow/src/shadow.cpp
@@ -855,6 +855,7 @@ int CommandLineParser::MainRoutine(vector<wstring> arguments)
 					ft.WriteLine(L"- Reason: %S", getCurrentExceptionDescription().c_str());
 					ft.WriteLine(L"- Ensuring that any half-created VSS snapshot gets deleted...");
 					m_vssClient.DeleteLatestSnapshotSet(true);
+					ft.WriteLine(L"- Half-created snapshot is deleted");
 				}
 				catch (...)
 				{

--- a/Samples/vshadow/src/shadow.cpp
+++ b/Samples/vshadow/src/shadow.cpp
@@ -94,7 +94,7 @@ std::string getCurrentExceptionDescription(const std::exception_ptr& ex = std::c
 	}
 	catch (...)
 	{
-		return "who knows";
+		return "unknown issue";
 	}
 }
 
@@ -852,14 +852,14 @@ int CommandLineParser::MainRoutine(vector<wstring> arguments)
 				try
 				{
 					ft.WriteLine(L"\nERROR: Failed to fully create snapshot");
-					ft.WriteLine(L"- Reason: %s", getCurrentExceptionDescription());
+					ft.WriteLine(L"- Reason: %S", getCurrentExceptionDescription().c_str());
 					ft.WriteLine(L"- Ensuring that any half-created VSS snapshot gets deleted...");
 					m_vssClient.DeleteLatestSnapshotSet(true);
 				}
 				catch (...)
 				{
 					ft.WriteLine(L"\nERROR: Failed to delete latest snapshot set");
-					ft.WriteLine(L"- Reason: %s", getCurrentExceptionDescription());
+					ft.WriteLine(L"- Reason: %S", getCurrentExceptionDescription().c_str());
 				}
 				// It's important to rethrow the exception so normal error handling continues as before
 				throw;


### PR DESCRIPTION
Message with returned code 2 happens when we catch the exception in efsvss.
There is a huge blocks that wrapped by try/catch statement.
Decided to create some common function to re-catch exception and print the reason.